### PR TITLE
remove previous t2 kernels but preserve current version

### DIFF
--- a/t2-kernel-script-lts/usr/bin/update_t2_kernel
+++ b/t2-kernel-script-lts/usr/bin/update_t2_kernel
@@ -40,7 +40,7 @@ latestk=$(echo $latest | cut -c 2- | cut -d "-" -f 1 | awk '{print $1"-t2"}')
 fi
 
 currentk=$(uname -r)
-
+existingK=($(dpkg --list | grep linux-image- | cut -d ' ' -f 2-3 ))
 if [ \( $latestk != $currentk \) ]; then
 	
 	echo "Downloading new kernel $latest"
@@ -54,12 +54,20 @@ if [ \( $latestk != $currentk \) ]; then
 	apt install ./image.deb
 	#shutdown -r 02:00 "reboot scheduled for the next 2am to update runnning kernel"
 	rm -f headers.deb image.deb
-	#uninstall old kernel
-		if [[ $(uname -r | cut -d "-" -f 2) = t2 ]]
-		then
-		dpkg -r linux-headers-$(uname -r)
-		dpkg -r linux-image-$(uname -r)
+
+	#uninstall old t2 kernels but preserve current version as a backup
+	for kernel in "${existingK[@]}"
+	do
+		if [ \( $kernel != linux-image-$currentk \) ]; then
+			echo "$kernel needs to be removed"
+			version=${kernel/#linux-image-}
+			#purge old t2 kernel
+			if [[ $(uname -r | cut -d "-" -f 2) = t2 ]]; then
+				dpkg -P linux-headers-$version
+				dpkg -P linux-image-$version
+			fi
 		fi
+	done
 	fi
 else
 echo "Kernel is up to date"

--- a/t2-kernel-script-lts/usr/bin/update_t2_kernel
+++ b/t2-kernel-script-lts/usr/bin/update_t2_kernel
@@ -4,11 +4,11 @@
 if [ $USER != root ]
 then
 sudo chmod 755 $0
-sudo $0 $1
+sudo $0 $1 $2
 exit 0
 fi
 
-if [[ $1 != -v ]]
+if [[ ($1 != -v) && ($2 != -v) ]]
 then
 exec 3>&1 4>&2
 trap 'exec 2>&4 1>&3' 0 1 2 3
@@ -40,7 +40,7 @@ latestk=$(echo $latest | cut -c 2- | cut -d "-" -f 1 | awk '{print $1"-t2"}')
 fi
 
 currentk=$(uname -r)
-existingK=($(dpkg --list | grep linux-image- | cut -d ' ' -f 2-3 ))
+existingK=($(dpkg --list | grep linux-image- | grep 't2\|mbp' | cut -d ' ' -f 2-3 ))
 if [ \( $latestk != $currentk \) ]; then
 	
 	echo "Downloading new kernel $latest"
@@ -48,26 +48,30 @@ if [ \( $latestk != $currentk \) ]; then
 	curl -L https://github.com/t2linux/T2-Ubuntu-Kernel/releases/download/${latest}/linux-image-${latestk}_${latestkver}_amd64.deb > image.deb
 
 	if [ -f headers.deb -a -f image.deb ]; then
-	#install
-	echo "Installing new kernel $latest"
-	apt install ./headers.deb
-	apt install ./image.deb
-	#shutdown -r 02:00 "reboot scheduled for the next 2am to update runnning kernel"
-	rm -f headers.deb image.deb
+		#install
+		echo "Installing new kernel $latest"
+		apt install ./headers.deb
+		apt install ./image.deb
+		#shutdown -r 02:00 "reboot scheduled for the next 2am to update runnning kernel"
+		rm -f headers.deb image.deb
 
-	#uninstall old t2 kernels but preserve current version as a backup
-	for kernel in "${existingK[@]}"
-	do
-		if [ \( $kernel != linux-image-$currentk \) ]; then
-			echo "$kernel needs to be removed"
-			version=${kernel/#linux-image-}
-			#purge old t2 kernel
-			if [[ $(uname -r | cut -d "-" -f 2) = t2 ]]; then
+		#uninstall old t2 kernels but preserve current version as a backup
+		for kernel in "${existingK[@]}"
+		do
+			if [ \( $kernel != linux-image-$currentk \) ]; then
+				echo "$kernel needs to be removed"
+				version=${kernel/#linux-image-}
+				#purge old t2 kernel
 				dpkg -P linux-headers-$version
 				dpkg -P linux-image-$version
 			fi
+		done
+		if [[ ($1 = --remove-current) || ($2 = --remove-current) ]]; then
+			echo "Current kernel linux-image-$currentk shall also be removed"
+
+			dpkg -P linux-headers-$currentk
+			dpkg -P linux-image-$currentk
 		fi
-	done
 	fi
 else
 echo "Kernel is up to date"

--- a/t2-kernel-script-lts/usr/bin/update_t2_kernel
+++ b/t2-kernel-script-lts/usr/bin/update_t2_kernel
@@ -4,15 +4,8 @@
 if [ $USER != root ]
 then
 sudo chmod 755 $0
-sudo $0 $1 $2
+sudo $0 $1
 exit 0
-fi
-
-if [[ ($1 != -v) && ($2 != -v) ]]
-then
-exec 3>&1 4>&2
-trap 'exec 2>&4 1>&3' 0 1 2 3
-exec 1>/var/log/t2-kernel-update.log 2>&1
 fi
 
 set -e
@@ -66,7 +59,7 @@ if [ \( $latestk != $currentk \) ]; then
 				dpkg -P linux-image-$version
 			fi
 		done
-		if [[ ($1 = --remove-current) || ($2 = --remove-current) ]]; then
+		if [[ ($1 = --remove-current) ]]; then
 			echo "Current kernel linux-image-$currentk shall also be removed"
 
 			dpkg -P linux-headers-$currentk

--- a/t2-kernel-script/usr/bin/update_t2_kernel
+++ b/t2-kernel-script/usr/bin/update_t2_kernel
@@ -40,7 +40,7 @@ latestk=$(echo $latest | cut -c 2- | cut -d "-" -f 1 | awk '{print $1"-t2"}')
 fi
 
 currentk=$(uname -r)
-
+existingK=($(dpkg --list | grep linux-image- | cut -d ' ' -f 2-3 ))
 if [ \( $latestk != $currentk \) ]; then
 	
 	echo "Downloading new kernel $latest"
@@ -54,12 +54,20 @@ if [ \( $latestk != $currentk \) ]; then
 	apt install ./image.deb
 	#shutdown -r 02:00 "reboot scheduled for the next 2am to update runnning kernel"
 	rm -f headers.deb image.deb
-	#uninstall old kernel
-		if [[ $(uname -r | cut -d "-" -f 2) = t2 ]]
-		then
-		dpkg -r linux-headers-$(uname -r)
-		dpkg -r linux-image-$(uname -r)
+
+	#uninstall old t2 kernels but preserve current version as a backup
+	for kernel in "${existingK[@]}"
+	do
+		if [ \( $kernel != linux-image-$currentk \) ]; then
+			echo "$kernel needs to be removed"
+			version=${kernel/#linux-image-}
+			#purge old t2 kernel
+			if [[ $(uname -r | cut -d "-" -f 2) = t2 ]]; then
+				dpkg -P linux-headers-$version
+				dpkg -P linux-image-$version
+			fi
 		fi
+	done
 	fi
 else
 echo "Kernel is up to date"

--- a/t2-kernel-script/usr/bin/update_t2_kernel
+++ b/t2-kernel-script/usr/bin/update_t2_kernel
@@ -4,11 +4,11 @@
 if [ $USER != root ]
 then
 sudo chmod 755 $0
-sudo $0 $1
+sudo $0 $1 $2
 exit 0
 fi
 
-if [[ $1 != -v ]]
+if [[ ($1 != -v) && ($2 != -v) ]]
 then
 exec 3>&1 4>&2
 trap 'exec 2>&4 1>&3' 0 1 2 3
@@ -40,7 +40,7 @@ latestk=$(echo $latest | cut -c 2- | cut -d "-" -f 1 | awk '{print $1"-t2"}')
 fi
 
 currentk=$(uname -r)
-existingK=($(dpkg --list | grep linux-image- | cut -d ' ' -f 2-3 ))
+existingK=($(dpkg --list | grep linux-image- | grep 't2\|mbp' | cut -d ' ' -f 2-3 ))
 if [ \( $latestk != $currentk \) ]; then
 	
 	echo "Downloading new kernel $latest"
@@ -48,26 +48,30 @@ if [ \( $latestk != $currentk \) ]; then
 	curl -L https://github.com/t2linux/T2-Ubuntu-Kernel/releases/download/${latest}/linux-image-${latestk}_${latestkver}_amd64.deb > image.deb
 
 	if [ -f headers.deb -a -f image.deb ]; then
-	#install
-	echo "Installing new kernel $latest"
-	apt install ./headers.deb
-	apt install ./image.deb
-	#shutdown -r 02:00 "reboot scheduled for the next 2am to update runnning kernel"
-	rm -f headers.deb image.deb
+		#install
+		echo "Installing new kernel $latest"
+		apt install ./headers.deb
+		apt install ./image.deb
+		#shutdown -r 02:00 "reboot scheduled for the next 2am to update runnning kernel"
+		rm -f headers.deb image.deb
 
-	#uninstall old t2 kernels but preserve current version as a backup
-	for kernel in "${existingK[@]}"
-	do
-		if [ \( $kernel != linux-image-$currentk \) ]; then
-			echo "$kernel needs to be removed"
-			version=${kernel/#linux-image-}
-			#purge old t2 kernel
-			if [[ $(uname -r | cut -d "-" -f 2) = t2 ]]; then
+		#uninstall old t2 kernels but preserve current version as a backup
+		for kernel in "${existingK[@]}"
+		do
+			if [ \( $kernel != linux-image-$currentk \) ]; then
+				echo "$kernel needs to be removed"
+				version=${kernel/#linux-image-}
+				#purge old t2 kernel
 				dpkg -P linux-headers-$version
 				dpkg -P linux-image-$version
 			fi
+		done
+		if [[ ($1 = --remove-current) || ($2 = --remove-current) ]]; then
+			echo "Current kernel linux-image-$currentk shall also be removed"
+
+			dpkg -P linux-headers-$currentk
+			dpkg -P linux-image-$currentk
 		fi
-	done
 	fi
 else
 echo "Kernel is up to date"

--- a/t2-kernel-script/usr/bin/update_t2_kernel
+++ b/t2-kernel-script/usr/bin/update_t2_kernel
@@ -4,15 +4,8 @@
 if [ $USER != root ]
 then
 sudo chmod 755 $0
-sudo $0 $1 $2
+sudo $0 $1
 exit 0
-fi
-
-if [[ ($1 != -v) && ($2 != -v) ]]
-then
-exec 3>&1 4>&2
-trap 'exec 2>&4 1>&3' 0 1 2 3
-exec 1>/var/log/t2-kernel-update.log 2>&1
 fi
 
 set -e
@@ -66,7 +59,7 @@ if [ \( $latestk != $currentk \) ]; then
 				dpkg -P linux-image-$version
 			fi
 		done
-		if [[ ($1 = --remove-current) || ($2 = --remove-current) ]]; then
+		if [[ ($1 = --remove-current) ]]; then
 			echo "Current kernel linux-image-$currentk shall also be removed"
 
 			dpkg -P linux-headers-$currentk


### PR DESCRIPTION
Updated the remove kernels logic to list current kernels and purge old t2 kernels but preserving current kernel as a backup.
This is useful in case there is any bug in any t2 drivers that could prevent the user from start the session.
