### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/apfs.yml
+++ b/.github/workflows/apfs.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: 'Checkout Repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.5.0
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -104,7 +104,7 @@ jobs:
           GPG_SIGNING_EMAIL: ${{ secrets.GPG_SIGNING_EMAIL }}
       - name: Publish
         if: env.publish == 'yes'
-        uses: cpina/github-action-push-to-another-repository@main
+        uses: cpina/github-action-push-to-another-repository@v1.5.1
         env:
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
         with:
@@ -130,7 +130,7 @@ jobs:
           git commit -m "Update APFS driver to v${{ env.ver }}" -a
       - name: Push changes to the repo
         if: env.publish == 'yes'
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'Checkout repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.5.0
       - name: 'Set up Python 3.9'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3.0
       - name: 'Install dependencies'
         run: |
           python -m pip install --upgrade pip
@@ -41,7 +41,7 @@ jobs:
           remove-haskell: 'true'
 
       - name: 'Checkout Repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.5.0
 
       - name: Build script
         id: build
@@ -61,14 +61,14 @@ jobs:
           ls -l
 
       - name: Upload package artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: linux-T2-${{ steps.build.outputs.tag }}
           path: /tmp/artifacts/*
 
       - name: Release
         if: github.ref == 'refs/heads/Mainline'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.14
         with:
           files: |
             /tmp/artifacts/Packages.gz

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.5.0
 
       - name: Configure GPG Key
         run: |
@@ -42,7 +42,7 @@ jobs:
           GPG_SIGNING_EMAIL: ${{ secrets.GPG_SIGNING_EMAIL }}
       - name: Publish
         if: github.ref == 'refs/heads/Mainline'
-        uses: cpina/github-action-push-to-another-repository@main
+        uses: cpina/github-action-push-to-another-repository@v1.5.1
         env:
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
         with:

--- a/.github/workflows/lts.yml
+++ b/.github/workflows/lts.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.5.0
 
       - name: Configure GPG Key
         run: |
@@ -42,7 +42,7 @@ jobs:
           GPG_SIGNING_EMAIL: ${{ secrets.GPG_SIGNING_EMAIL }}
       - name: Publish
         if: github.ref == 'refs/heads/Mainline'
-        uses: cpina/github-action-push-to-another-repository@main
+        uses: cpina/github-action-push-to-another-repository@v1.5.1
         env:
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
         with:

--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.5.0
 
       - name: Configure GPG Key
         run: |
@@ -43,7 +43,7 @@ jobs:
           GPG_SIGNING_EMAIL: ${{ secrets.GPG_SIGNING_EMAIL }}
       - name: Publish
         if: github.ref == 'refs/heads/Mainline'
-        uses: cpina/github-action-push-to-another-repository@main
+        uses: cpina/github-action-push-to-another-repository@v1.5.1
         env:
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
         with:

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5.0
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[softprops/action-gh-release](https://github.com/softprops/action-gh-release)** published a new release [v0.1.14](https://github.com/softprops/action-gh-release/releases/tag/v0.1.14) on 2021-11-15T06:34:34Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release [v4.3.0](https://github.com/actions/setup-python/releases/tag/v4.3.0) on 2022-10-10T11:36:21Z
* **[ad-m/github-push-action](https://github.com/ad-m/github-push-action)** published a new release [v0.6.0](https://github.com/ad-m/github-push-action/releases/tag/v0.6.0) on 2020-05-26T20:53:18Z
* **[cpina/github-action-push-to-another-repository](https://github.com/cpina/github-action-push-to-another-repository)** published a new release [v1.5.1](https://github.com/cpina/github-action-push-to-another-repository/releases/tag/v1.5.1) on 2022-09-05T22:41:38Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v2.5.0](https://github.com/actions/checkout/releases/tag/v2.5.0) on 2022-10-13T15:51:55Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release [v3.1.0](https://github.com/actions/upload-artifact/releases/tag/v3.1.0) on 2022-05-20T14:38:03Z
