### PR TITLE
feat: enable Android devices

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -111,8 +111,8 @@ cp -v "${WORKING_PATH}/templates/default-config-${CONFIG}" "${KERNEL_PATH}/.conf
 ./scripts/config --undefine DEBUG_INFO_COMPRESSED
 ./scripts/config --set-val  DEBUG_INFO_NONE       y
 ./scripts/config --set-val  DEBUG_INFO_DWARF5     n
-./scripts/config --enable CONFIG_ANDROID_BINDER_IPC
-./scripts/config --enable CONFIG_ANDROID_BINDERFS
+./scripts/config --enable   CONFIG_ANDROID_BINDER_IPC
+./scripts/config --enable   CONFIG_ANDROID_BINDERFS
 ./scripts/config --set-str  CONFIG_ANDROID_BINDER_DEVICES "binder,hwbinder,vndbinder"
 
 make olddefconfig

--- a/build.sh
+++ b/build.sh
@@ -111,6 +111,8 @@ cp -v "${WORKING_PATH}/templates/default-config-${CONFIG}" "${KERNEL_PATH}/.conf
 ./scripts/config --undefine DEBUG_INFO_COMPRESSED
 ./scripts/config --set-val  DEBUG_INFO_NONE       y
 ./scripts/config --set-val  DEBUG_INFO_DWARF5     n
+./scripts/config --enable CONFIG_ANDROID_BINDER_IPC
+./scripts/config --enable CONFIG_ANDROID_BINDERFS
 
 make olddefconfig
 

--- a/build.sh
+++ b/build.sh
@@ -113,6 +113,7 @@ cp -v "${WORKING_PATH}/templates/default-config-${CONFIG}" "${KERNEL_PATH}/.conf
 ./scripts/config --set-val  DEBUG_INFO_DWARF5     n
 ./scripts/config --enable CONFIG_ANDROID_BINDER_IPC
 ./scripts/config --enable CONFIG_ANDROID_BINDERFS
+./scripts/config --set-str  CONFIG_ANDROID_BINDER_DEVICES "binder,hwbinder,vndbinder"
 
 make olddefconfig
 


### PR DESCRIPTION
To be able to use [waydroid](https://waydro.id/) some additional config flags need to be enabled. This PR does exactly that. I've build it locally and installed the Kernel (.deb files). So far, all looks fine on my side. If nothing speaks against it, I'd be happt to see this enbabled by default. 