### PR TITLE
Enable CONFIG_DEBUG_INFO_BTF for eBPF CO-RE (Cilium, bpftrace, libbpf)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -103,14 +103,20 @@ sed -i 's/CONFIG_MESSAGE_LOGLEVEL_DEFAULT=.*/CONFIG_MESSAGE_LOGLEVEL_DEFAULT=4/g
 # Copy the modified config
 cp -v "${WORKING_PATH}/templates/default-config-${CONFIG}" "${KERNEL_PATH}/.config"
 
-# Disable debug info
+# Enable BTF type information for eBPF CO-RE tooling (Cilium, bpftrace, libbpf).
+# BTF is generated from DWARF by pahole (dwarves, already a build dependency),
+# so debug info must stay on; DWARF5 is the most compact. BTF additionally
+# requires that split/reduced debug info remain disabled. DWARF is not carried
+# into the shipped vmlinuz, so the installed kernel image stays lean -- only the
+# build host pays the cost.
 ./scripts/config --undefine GDB_SCRIPTS
-./scripts/config --undefine DEBUG_INFO
 ./scripts/config --undefine DEBUG_INFO_SPLIT
 ./scripts/config --undefine DEBUG_INFO_REDUCED
 ./scripts/config --undefine DEBUG_INFO_COMPRESSED
-./scripts/config --set-val  DEBUG_INFO_NONE       y
-./scripts/config --set-val  DEBUG_INFO_DWARF5     n
+./scripts/config --disable  DEBUG_INFO_NONE
+./scripts/config --enable   DEBUG_INFO_DWARF5
+./scripts/config --enable   DEBUG_INFO_BTF
+./scripts/config --enable   DEBUG_INFO_BTF_MODULES
 ./scripts/config --enable   CONFIG_ANDROID_BINDER_IPC
 ./scripts/config --enable   CONFIG_ANDROID_BINDERFS
 ./scripts/config --set-str  CONFIG_ANDROID_BINDER_DEVICES "binder,hwbinder,vndbinder"


### PR DESCRIPTION
## Problem

The Ubuntu and Debian config templates already ship `CONFIG_DEBUG_INFO_BTF=y`
(plus `DEBUG_INFO_BTF_MODULES`), but `build.sh` then disables it:

```sh
./scripts/config --undefine DEBUG_INFO
./scripts/config --set-val  DEBUG_INFO_NONE   y
./scripts/config --set-val  DEBUG_INFO_DWARF5 n
```

`CONFIG_DEBUG_INFO_BTF` is generated from DWARF by pahole, so turning debug
info off silently drops BTF through its kconfig dependency. The resulting
kernels expose **no `/sys/kernel/btf/vmlinux`**.

## Impact

Any eBPF CO-RE consumer fails its kernel-requirement probe on T2 kernels:
`bpftrace`, `libbpf`-based tooling, and notably **Cilium**, which
hard-requires kernel BTF. On a current `7.1.0-3-t2-noble` kernel:

```
$ ls /sys/kernel/btf/vmlinux
ls: cannot access '/sys/kernel/btf/vmlinux': No such file or directory
$ grep DEBUG_INFO_BTF /boot/config-7.1.0-3-t2-noble   # (nothing)
```

This blocks running a T2 Mac as a Kubernetes node on any Cilium-based
cluster.

## Fix

Keep DWARF debug info enabled through the build (DWARF5, the most compact
form) so pahole can emit BTF, and enable `DEBUG_INFO_BTF` +
`DEBUG_INFO_BTF_MODULES`. `dwarves` is already in the build dependencies, so
no new tooling is required. `make olddefconfig` (already run right after the
`scripts/config` block) resolves the dependencies.

## Cost / notes

- DWARF is **not** carried into the shipped `vmlinuz`, so the installed
  `linux-image` stays lean — only the build host pays extra CPU/RAM/disk.
- Enabling debug info does cause `make deb-pkg` to also emit a large
  `linux-image-*-dbg` package. There is already a commented-out
  `#rm /tmp/artifacts/*dbg*` in `kernel.yml`; un-commenting it keeps the
  published artifacts lean. Happy to fold that into this PR if you'd prefer.

## Testing

Built from this branch via CI on the `ubuntu:24.04` (noble) target and
installed on a MacBookPro15,4 (T2). I'll confirm `/sys/kernel/btf/vmlinux`
is present on the booted kernel and report back in a comment once the build
finishes.